### PR TITLE
Revert "chore: update dependabot.yml"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,19 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    labels: 
-      - "dependencies"
-    allow:
-      - dependency-type: "production"
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    labels: 
-      - "devDependencies"
-    allow:
-      - dependency-type: "development"


### PR DESCRIPTION
Reverts korosuke613/linear-webhook#33

Because it's currently, update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch’.

```
Dependabot encountered the following error when parsing your .github/dependabot.yml:

The property '#/updates/1' is a duplicate. Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'
Please update the config file to conform with Dependabot's specification.

Learn more or give us feedback
```

dependabot-core has an issue.  https://github.com/dependabot/dependabot-core/issues/2390